### PR TITLE
vimc-4375: fix bug in the extract_vaccination_history function

### DIFF
--- a/R/commonly_used_db_data.R
+++ b/R/commonly_used_db_data.R
@@ -106,6 +106,10 @@ extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touc
                                 AND gavi_support_level != 'none'", touchstone_cov)
     cov_sets2 <- merge_by_common_cols(disease_vaccine_delivery, cov_sets2, all.x = TRUE)
     cov_sets2$scenario_type <- "default"
+    cov_sets2$scenario_description <- paste(cov_sets2$vaccine,
+                                            cov_sets2$activity_type,
+                                            cov_sets2$gavi_support_level,
+                                            sep = "-")
     cov_sets <- cov_sets2[names(cov_sets)]
   }
 


### PR DESCRIPTION
https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-4375

When I first modify the function I introduce a bug. This PR is to try to fix it by including the scenario_description variable after an if statement. 

Test with the following: 

`p_int_pop <- vimpact::get_population(con, 
                                     touchstone_pop = "201810synthetic",
                                     demographic_statistic = "int_pop", 
                                     gender = c("Both", "Female", "Male"), 
                                     year_ = 2000:2030)`


`fvps_df<- vimpact::extract_vaccination_history(con, 
                                               touchstone_cov = "201810gavi", 
                                               year_min = 2000, 
                                               year_max = 2030,
                                               gavi_support_levels = "with", 
                                               external_population_estimates = p_int_pop)`

After the modification, the above should run and get fvps dataframe. 