### PR TITLE
vimc-4831: fix testing extract_vaccination_history

### DIFF
--- a/R/commonly_used_db_data.R
+++ b/R/commonly_used_db_data.R
@@ -34,7 +34,7 @@ get_touchstone <- function(con, touchstone_name){
 ##' @param scenario_type scenario type
 ##' @param external_population_estimates The rationales are 1. we can use external population estimates if any and if necessary;
 ##' 2. demographic uncertainty not only affects models, but also FVPs. If we are to conduct sensitivity analysis on impact_by_year_of_vaccination, we need to vary population input for adjusting FVPs.
-##' @param full_description TRUE if including scenario_descriptions (coverage estiamtes will be duplicated for scenarios); and FALSE if only providing coverage estimates
+##' @param full_description TRUE if including scenario_descriptions (coverage estimates will be duplicated for scenarios); and FALSE if only providing coverage estimates
 ##' @export
 extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touchstone_pop = NULL,
                                         year_min = 2000, year_max = 2100,
@@ -42,7 +42,7 @@ extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touc
                                         disease_to_extract = NULL,
                                         countries_to_extract = NULL,
                                         gavi_support_levels = c("with", "bestminus"),
-                                        scenario_type = "default", external_population_estimates = NULL, full_description = TRUE) {
+                                        scenario_type = "default", external_population_estimates = NULL, full_description = FALSE) {
 
   ### This function converts input coverage data to be dis-aggregated by gender and age
   ### i.e. input data by country, year and age

--- a/man/extract_vaccination_history.Rd
+++ b/man/extract_vaccination_history.Rd
@@ -16,7 +16,7 @@ extract_vaccination_history(
   gavi_support_levels = c("with", "bestminus"),
   scenario_type = "default",
   external_population_estimates = NULL,
-  full_description = TRUE
+  full_description = FALSE
 )
 }
 \arguments{
@@ -43,7 +43,7 @@ extract_vaccination_history(
 \item{external_population_estimates}{The rationales are 1. we can use external population estimates if any and if necessary;
 2. demographic uncertainty not only affects models, but also FVPs. If we are to conduct sensitivity analysis on impact_by_year_of_vaccination, we need to vary population input for adjusting FVPs.}
 
-\item{full_description}{TRUE if including scenario_descriptions (coverage estiamtes will be duplicated for scenarios); and FALSE if only providing coverage estimates}
+\item{full_description}{TRUE if including scenario_descriptions (coverage estimates will be duplicated for scenarios); and FALSE if only providing coverage estimates}
 }
 \description{
 Replace jenner:::fix_covreage_fvps() function

--- a/tests/testthat/test_commonly_used_db_data.R
+++ b/tests/testthat/test_commonly_used_db_data.R
@@ -8,13 +8,12 @@ test_that("test get_touchstone",{
 })
 
 test_that("test extract_vaccination_history",{
-  testthat::skip("TODO: test not working")
   con <- test_montagu_readonly_connection()
   test_data <- readRDS("vimpact-test-data/fvps.rds")
   test_data <- stats::aggregate(fvps ~ country + year + vaccine + activity_type, test_data, sum, na.rm = TRUE)
   dat <- extract_vaccination_history(con, touchstone_cov = "201710gavi", year_min = 2000, year_max = 2100,
                                      countries_to_extract = unique(test_data$country),
-                                     disease_to_extract = c("HepB", "Measles", "YF"))
+                                     disease_to_extract = c("HepB", "Measles", "YF"), full_description = FALSE)
   dat <- stats::aggregate(fvps_adjusted ~ country + year + vaccine + activity_type, dat, sum, na.rm = TRUE)
 
   d <- merge(dat, test_data, by = intersect(names(dat), names(test_data)), all = TRUE)
@@ -23,7 +22,9 @@ test_that("test extract_vaccination_history",{
   d$diff <- round(d$fvps_adjusted - d$fvps)
 
   expect_true(all(d$diff[d$activity_type == "routine"] == 0))
-  message("Only PAK 2015 Measles SIA has discrepancy. Please double check.")
+  message("Only PAK 2015 Measles SIA has discrepancy.
+          It is because previous and current approach cap campaign coverage at 100% differently.
+          Current approahc is more accurate.")
 
 })
 


### PR DESCRIPTION
youtrack:
https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-4831

task:
fix function. the failed test is due to a newly added parameter, which causes duplications in the test.