### PR TITLE
vimc-6009: fix a tiny bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vimpact
 Title: Vaccine Impact Calculation
-Version: 0.0.7
+Version: 0.0.8
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# vimpact 0.0.8
+
+* Fix impact_meta.R.
+
 # vimpact 0.0.7
 
 * Fix both csv and function interfaces, so that they work for 2021 runs and generate identical results.

--- a/R/impact_meta.R
+++ b/R/impact_meta.R
@@ -121,11 +121,11 @@ get_meta_from_recipe <- function(default_recipe = TRUE, method = "method0", reci
 
     meta_all <- DBI::dbGetQuery(con, sql)
     ## remove yf reactive sias - otherwise cannot match with recipe
-    i <- meta_all$scenario_type == "novac"
+    l <- meta_all$scenario_type == "novac"
     j <- meta_all$gavi_support_level == "none"
-    meta_all$vaccine[i & j] <- "none"
+    meta_all$vaccine[l & j] <- "none"
     meta_all$activity_type[i & j] <- "none"
-    meta_all <- meta_all[!(!i & j), ]
+    meta_all <- meta_all[!(!l & j), ]
     meta_all$gavi_support_level <- NULL
     meta_all$vaccine_delivery <- paste(meta_all$vaccine, meta_all$activity_type, sep = "-")
     meta_all$vaccine_delivery[meta_all$vaccine_delivery == "none-none"] <- ""


### PR DESCRIPTION
Youtrack:
https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-6009

This is a tiny bug I just noticed. The `i` is used in for the `for()` loop, and within at the same time.