### PR TITLE
vimc-7724: update to allow in-memory db

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^TODO.md$
 ^.github$
 ^vignettes_src$
+^\.github$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,16 +1,13 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -22,69 +19,33 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v4
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Start test DB
-        if: runner.os == 'Linux'
-        run: ./scripts/test_db_start.sh
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -26,7 +26,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -30,7 +30,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,62 +1,62 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v4
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          use-public-rspm: true
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-          sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
-
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("covr")
-        shell: Rscript {0}
-
-      - name: Start test DB
-        if: runner.os == 'Linux'
-        run: ./scripts/test_db_start.sh
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov()
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/R/commonly_used_db_data.R
+++ b/R/commonly_used_db_data.R
@@ -59,6 +59,7 @@ get_touchstone_id <- function(con, touchstone) {
 ##' @param demographic_source Demographic_source.code
 ##' @param coverage_scenario_type Coverage scenario type. This is particularly useful for a coverage touchstone. Montagu coverage.name follows <disease>:<vaccine>,<activity_type>,<gavi_support_level>:<coverage_scenario_type>
 ##' It is NULL by default. When it is not null, only pulls coverage.name that contains specified pattern.
+##' @param db_memory if not null, coverage is pulled from in-memory db; this is used from 202507july onwards, as we are moving away from db imports
 ##' @export
 extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touchstone_pop = NULL,
                                         year_min = 2000, year_max = 2100,
@@ -70,7 +71,8 @@ extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touc
                                         external_population_estimates = NULL,
                                         full_description = FALSE,
                                         demographic_source = NULL,
-                                        coverage_scenario_type = NULL) {
+                                        coverage_scenario_type = NULL,
+                                        db_memory = NULL) {
 
   ## validate demography parameter
   ## when touchstone_pop is null, touchstone_cov is used for touchstone_pop
@@ -84,25 +86,32 @@ extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touc
 
   ### This function converts input coverage data to be dis-aggregated by gender and age
   ### i.e. input data by country, year and age
-
+  ### determine where to pull coverage
+  if(!is.null(db_memory)){
+    con_cov <- db_memory
+  } else {
+    con_cov <- con
+  }
   ## 1. touchstone specification
   ## which coverage touchstone to use - given touchstone name, use the latest version touchstone
   if (grepl("-", touchstone_cov)) {
-    tmp <- DBI::dbGetQuery(con, "SELECT * FROM touchstone WHERE id = $1", touchstone_cov)
+    tmp <- DBI::dbGetQuery(con_cov, "SELECT * FROM touchstone WHERE id = $1", touchstone_cov)
     if (nrow(tmp) == 1L) {
       message("User defined touchstone version is used.")
     } else {
       stop("User defined touchstone does not exist.")
     }
   } else {
-    touchstone_cov <- get_touchstone(con, touchstone_cov)
+    touchstone_cov <- get_touchstone(con_cov, touchstone_cov)
   }
 
   ## which demographic touchstone to use
-  if (is.null(touchstone_pop)) {
+  if(!is.null(touchstone_pop)){
+    touchstone_pop <- get_touchstone(con, touchstone_pop)
+  } else if(is.null(touchstone_pop) & is.null(db_memory)){
     touchstone_pop <- touchstone_cov
   } else {
-    touchstone_pop <- get_touchstone(con, touchstone_pop)
+    message("touchstone_pop is rulled out")
   }
 
   message("Converting input coverage data......")
@@ -124,7 +133,8 @@ extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touc
   ## select minimal needed coverage data from the db
   disease_vaccine_delivery <- read_csv(system_file("disease_vaccine_delivery.csv"))
 
-  cov_sets <- DBI::dbGetQuery(con, paste(sprintf("SELECT DISTINCT scenario_type, scenario_description, disease, coverage_set.id AS coverage_set, vaccine, activity_type, gavi_support_level
+  if(all(c("scenario_description", "scenario_type", "scenario", "scenario_coverage_set") %in% DBI::dbListTables(con_cov))){
+    cov_sets <- DBI::dbGetQuery(con_cov, paste(sprintf("SELECT DISTINCT scenario_type, scenario_description, disease, coverage_set.id AS coverage_set, vaccine, activity_type, gavi_support_level
                               FROM scenario
                               JOIN scenario_coverage_set
                               ON scenario_coverage_set.scenario = scenario.id
@@ -136,14 +146,18 @@ extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touc
                               AND scenario_type IN %s
                               AND gavi_support_level IN %s
                               AND vaccine NOT IN %s",
-                                                 sql_in(scenario_type),
-                                                 sql_in(gavi_support_levels),
-                                                 sql_in(vaccine_to_ignore)),
-                                         "AND scenario_description NOT LIKE '%LiST%'"),
-                              touchstone_cov)
+                                                       sql_in(scenario_type),
+                                                       sql_in(gavi_support_levels),
+                                                       sql_in(vaccine_to_ignore)),
+                                               "AND scenario_description NOT LIKE '%LiST%'"),
+                                touchstone_cov)
+  } else {
+    cov_sets <- data.frame(NULL)
+  }
+
   if (nrow(cov_sets) == 0L) {
     # this is not a model run touchstone, need to extract coverage set directly
-    cov_sets2 <- DBI::dbGetQuery(con, "SELECT name, coverage_set.id AS coverage_set, vaccine, activity_type, gavi_support_level
+    cov_sets2 <- DBI::dbGetQuery(con_cov, "SELECT name, coverage_set.id AS coverage_set, vaccine, activity_type, gavi_support_level
                                 FROM coverage_set
                                 WHERE touchstone = $1
                                 AND gavi_support_level != 'none'", touchstone_cov)
@@ -166,16 +180,16 @@ extract_vaccination_history <- function(con, touchstone_cov = "201710gavi", touc
                      "",
                      sprintf("AND country IN %s", sql_in(countries_to_extract, text_item = TRUE)))
 
-  cov <- DBI::dbGetQuery(con, sprintf("SELECT coverage_set, country, year, age_from, age_to, gender.name AS gender, gavi_support, target, coverage
+  cov <- DBI::dbGetQuery(con_cov, sprintf("SELECT coverage_set, country, year, age_from, age_to, gender.name AS gender, gavi_support, target, coverage
                                       FROM coverage
                                       JOIN gender ON gender.id = gender
                                       WHERE coverage_set IN %s
                                       AND coverage > 0
                                       AND year IN %s
                                       %s",
-                                      sql_in(unique(cov_sets$coverage_set), text_item = FALSE),
-                                      sql_in(year_min:year_max, text_item = FALSE),
-                                      country_))
+                                          sql_in(unique(cov_sets$coverage_set), text_item = FALSE),
+                                          sql_in(year_min:year_max, text_item = FALSE),
+                                          country_))
 
   message("Extracted raw coverage data...")
   ## transform coverage data

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,8 +2,8 @@
 
 <!-- badges: start -->
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
-[![Build Status](https://travis-ci.com/vimc/vimpact.svg?branch=master)](https://travis-ci.com/vimc/vimpact)
-[![codecov.io](https://codecov.io/github/vimc/vimpact/coverage.svg?branch=master)](https://codecov.io/github/vimc/vimpact?branch=master)
+[![R-CMD-check](https://github.com/vimc/vimpact/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/vimc/vimpact/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/vimc/vimpact/graph/badge.svg)](https://app.codecov.io/gh/vimc/vimpact)
 <!-- badges: end -->
 
 Support code for impact calculations.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <!-- badges: start -->
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
-[![Build Status](https://travis-ci.com/vimc/vimpact.svg?branch=master)](https://travis-ci.com/vimc/vimpact)
-[![codecov.io](https://codecov.io/github/vimc/vimpact/coverage.svg?branch=master)](https://codecov.io/github/vimc/vimpact?branch=master)
+[![R-CMD-check](https://github.com/vimc/vimpact/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/vimc/vimpact/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/vimc/vimpact/graph/badge.svg)](https://app.codecov.io/gh/vimc/vimpact)
 <!-- badges: end -->
 
 Support code for impact calculations.

--- a/inst/disease_vaccine_delivery.csv
+++ b/inst/disease_vaccine_delivery.csv
@@ -1,5 +1,7 @@
 disease,vaccine,activity_type
 Cholera,Cholera,campaign
+Cholera,OCV1,campaign
+Cholera,OCV2,campaign
 DTP,DTP3,routine
 HepB,HepB,routine
 HepB,HepB_BD,routine
@@ -16,6 +18,8 @@ Measles,Measles,campaign
 Measles,Measles,routine-intensified
 MenA,MenA,campaign
 MenA,MenA,routine
+MenA,MenACWYX,campaign
+MenA,MenACWYX,routine
 MenA,MenA,routine-intensified
 PCV,PCV3,routine
 Rota,Rota,routine
@@ -28,3 +32,9 @@ Typhoid,Typhoid,routine
 YF,YF,campaign
 YF,YF,routine
 YF,YF,routine-intensified
+Malaria,R3,routine
+Malaria,R4,routine
+Malaria,RTS3,routine
+Malaria,RTS4,routine
+COVID,COVID,campaign
+COVID,COVID,routine

--- a/man/extract_vaccination_history.Rd
+++ b/man/extract_vaccination_history.Rd
@@ -22,7 +22,8 @@ extract_vaccination_history(
   external_population_estimates = NULL,
   full_description = FALSE,
   demographic_source = NULL,
-  coverage_scenario_type = NULL
+  coverage_scenario_type = NULL,
+  db_memory = NULL
 )
 }
 \arguments{
@@ -55,6 +56,8 @@ extract_vaccination_history(
 
 \item{coverage_scenario_type}{Coverage scenario type. This is particularly useful for a coverage touchstone. Montagu coverage.name follows <disease>:<vaccine>,<activity_type>,<gavi_support_level>:<coverage_scenario_type>
 It is NULL by default. When it is not null, only pulls coverage.name that contains specified pattern.}
+
+\item{db_memory}{if not null, coverage is pulled from in-memory db; this is used from 202507july onwards, as we are moving away from db imports}
 }
 \description{
 Replace jenner:::fix_covreage_fvps() function


### PR DESCRIPTION
This is the first step for moving away from the db. It allows using in-memory db for pulling coverage touchstone.